### PR TITLE
Clean up a lot of warnings 

### DIFF
--- a/Chip8Dump/MemDumpApp.cpp
+++ b/Chip8Dump/MemDumpApp.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
     const bool noFile = noFileDumpSwitch.getValue();
     const int ratio = FloorAtZero(windowRatioArg.getValue());
 
-    std::optional<std::ofstream> output = std::nullopt;
+    std::optional<std::ofstream> output;
     if (!noFile) {
         const std::string ofname = filename + "_" + CurrentDate() + "_dump.txt";
         output = std::ofstream(ofname);
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     auto memoryPtr = std::make_shared<Chip8::Memory>();
-    auto& memory = *memoryPtr.get();
+    auto& memory = *memoryPtr;
     memory.LoadProgram(content);
 
     Chip8::Machine machine(screenPtr, memoryPtr);

--- a/Chip8Dump/MemDumpApp.cpp
+++ b/Chip8Dump/MemDumpApp.cpp
@@ -16,7 +16,7 @@
 #include <SDL.h>
 #include <tclap/CmdLine.h>
 
-static std::string ExecNextInstruction(Chip8::Memory& memory, Chip8::Machine& machine)
+[[noreturn]]static std::string ExecNextInstruction(Chip8::Memory& memory, Chip8::Machine& machine)
 {
     const std::uint16_t opcode = memory.NextInstruction();
     machine.HandleEvents();

--- a/Chip8Dump/MemDumpApp.cpp
+++ b/Chip8Dump/MemDumpApp.cpp
@@ -16,7 +16,7 @@
 #include <SDL.h>
 #include <tclap/CmdLine.h>
 
-[[noreturn]]static std::string ExecNextInstruction(Chip8::Memory& memory, Chip8::Machine& machine)
+[[noreturn]] static std::string ExecNextInstruction(Chip8::Memory& memory, Chip8::Machine& machine)
 {
     const std::uint16_t opcode = memory.NextInstruction();
     machine.HandleEvents();

--- a/Chip8Emulator.Core/CPU.cpp
+++ b/Chip8Emulator.Core/CPU.cpp
@@ -2,14 +2,15 @@
 
 #include <cassert>
 #include <random>
+#include <utility>
 #include <sdl_assert.h>
 
-Chip8::CPU::CPU(std::shared_ptr<Screen> screen, std::shared_ptr<Memory> memory, std::shared_ptr<Keyboard> keyboard)
-    : m_screenPtr(screen)
+Chip8::CPU::CPU(std::shared_ptr<Screen> screen, const std::shared_ptr<Memory>& memory, const std::shared_ptr<Keyboard>& keyboard)
+    : m_screenPtr(std::move(screen))
     , m_memoryPtr(memory)
-    , m_memory(*memory.get())
+    , m_memory(*memory)
     , m_keyboardPtr(keyboard)
-    , m_keyboard(*keyboard.get())
+    , m_keyboard(*keyboard)
 {}
 
 void Chip8::CPU::CLS() const
@@ -145,7 +146,7 @@ std::vector<Chip8::Screen::Point> PointsToDraw(const std::vector<uint8_t>& sprit
             const bool isOn = (line & offset) != 0;
             if (isOn)
             {
-                toDraw.push_back({ x + point.first, y + point.second });
+                toDraw.emplace_back( x + point.first, y + point.second );
             }
         }
     }
@@ -173,7 +174,7 @@ void Chip8::CPU::DRW(const std::uint8_t ls4b, const std::uint8_t x, const std::u
         const uint8_t x2 = pt.first % base_width;
         const uint8_t y2 = pt.second % base_height;
         collides |= m_screenPtr->Collides(x2, y2);
-        wrappedPoints.push_back({ x2, y2 });
+        wrappedPoints.emplace_back( x2, y2 );
     }
     m_memory.VX[0xF] = collides ? 1 : 0;
     m_screenPtr->DrawSprite(wrappedPoints);

--- a/Chip8Emulator.Core/Machine.cpp
+++ b/Chip8Emulator.Core/Machine.cpp
@@ -1,6 +1,7 @@
 #include "Machine.hpp"
 
 #include <iostream>
+#include <utility>
 
 #include "Instructions.hpp"
 #include "Keyboard.hpp"
@@ -12,18 +13,18 @@
 // I think it suits to the use case
 using namespace Chip8::Utils::Instructions;
 
-Chip8::Machine::Machine(std::shared_ptr<Screen> screen, std::shared_ptr<Memory> memory, std::shared_ptr<Keyboard> keyboard)
+Chip8::Machine::Machine(std::shared_ptr<Screen> screen, const std::shared_ptr<Memory>& memory, const std::shared_ptr<Keyboard>& keyboard)
     : m_memoryPtr(memory)
     , m_keyboardPtr(keyboard)
-    , m_cpu(CPU(screen, memory, keyboard))
+    , m_cpu(CPU(std::move(screen), memory, keyboard))
 {
     InitTimers();
 }
 
-Chip8::Machine::Machine(std::shared_ptr<Screen> screen, std::string filepath)
+Chip8::Machine::Machine(std::shared_ptr<Screen> screen, const std::string& filepath)
     : m_memoryPtr(std::make_shared<Memory>())
     , m_keyboardPtr(std::make_shared<Keyboard>())
-    , m_cpu(CPU(screen, m_memoryPtr, m_keyboardPtr))
+    , m_cpu(CPU(std::move(screen), m_memoryPtr, m_keyboardPtr))
 {
     std::vector<char> content;
     if (!Chip8::Utils::LoadFile(content, filepath))
@@ -39,7 +40,7 @@ Chip8::Machine::Machine(std::shared_ptr<Screen> screen, std::string filepath)
 void Chip8::Machine::InitTimers()
 {
     constexpr double delayMs = 1000.0 / 60;
-    constexpr int delay = static_cast<int>(delayMs * 1,000,000);
+    constexpr int delay = static_cast<int>(delayMs * 1'000'000);
     Memory& mem = *m_memoryPtr;
     auto& dt = mem.DT;
     auto& st = mem.ST;

--- a/Chip8Emulator.Core/Screen.cpp
+++ b/Chip8Emulator.Core/Screen.cpp
@@ -10,17 +10,17 @@
 #include "sdl_renderer.hpp"
 #include "sdl_window.hpp"
 
-SDL2::Window CreateWindow(std::shared_ptr<SDL2::SDL> sdl, const std::uint8_t ratio, const char* title)
+SDL2::Window CreateWindow(const std::shared_ptr<SDL2::SDL>& sdl, const std::uint8_t ratio, const char* title)
 {
     assert((*sdl.get()).Running());
 
     const int width = static_cast<int>(Chip8::base_width) * ratio;
     const int height = static_cast<int>(Chip8::base_height) * ratio;
 
-    return SDL2::Window(title,
+    return {title,
         SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED,
-        width, height, 0);
+        width, height, 0};
 }
 
 void Chip8::Screen::ResetGrid(PixelGrid& grid)
@@ -38,7 +38,7 @@ Chip8::Screen::PixelGrid Chip8::Screen::InitGrid()
     return grid;
 }
 
-Chip8::Screen::Screen(const std::shared_ptr<SDL2::SDL> sdl, const std::uint8_t ratio, const char* title)
+Chip8::Screen::Screen(const std::shared_ptr<SDL2::SDL>& sdl, const std::uint8_t ratio, const char* title)
     : m_sdl(sdl)
     , m_ratio(ratio)
     , m_window(CreateWindow(sdl, ratio, title))

--- a/Chip8Emulator.Core/include/CPU.hpp
+++ b/Chip8Emulator.Core/include/CPU.hpp
@@ -23,7 +23,7 @@ namespace Chip8
         SDL_Event m_event {};
 
     public:
-        CPU(std::shared_ptr<Screen> screen, std::shared_ptr<Memory> memory, std::shared_ptr<Keyboard> keyboard);
+        CPU(std::shared_ptr<Screen> screen, const std::shared_ptr<Memory>& memory, const std::shared_ptr<Keyboard>& keyboard);
 
         void CLS() const;
         void RET() const;

--- a/Chip8Emulator.Core/include/Machine.hpp
+++ b/Chip8Emulator.Core/include/Machine.hpp
@@ -30,6 +30,6 @@ namespace Chip8
 
         void ExecuteNextInstruction();
         void Execute(std::uint16_t opcode);
-        void HandleEvents();
+        [[noreturn]]void HandleEvents();
     };
 }

--- a/Chip8Emulator.Core/include/Machine.hpp
+++ b/Chip8Emulator.Core/include/Machine.hpp
@@ -25,8 +25,8 @@ namespace Chip8
         void InitTimers();
 
     public:
-        Machine(std::shared_ptr<Screen> screen, std::shared_ptr<Memory> memory, std::shared_ptr<Keyboard> keyboard = std::make_shared<Keyboard>());
-        Machine(std::shared_ptr<Screen> screen, std::string filepath);
+        Machine(std::shared_ptr<Screen> screen, const std::shared_ptr<Memory>& memory, const std::shared_ptr<Keyboard>& keyboard = std::make_shared<Keyboard>());
+        Machine(std::shared_ptr<Screen> screen, const std::string& filepath);
 
         void ExecuteNextInstruction();
         void Execute(std::uint16_t opcode);

--- a/Chip8Emulator.Core/include/Machine.hpp
+++ b/Chip8Emulator.Core/include/Machine.hpp
@@ -30,6 +30,6 @@ namespace Chip8
 
         void ExecuteNextInstruction();
         void Execute(std::uint16_t opcode);
-        [[noreturn]]void HandleEvents();
+        [[noreturn]] void HandleEvents();
     };
 }

--- a/Chip8Emulator.Core/include/Screen.hpp
+++ b/Chip8Emulator.Core/include/Screen.hpp
@@ -19,7 +19,7 @@ namespace Chip8
         using PixelGrid = std::array<std::array<bool, base_width>, base_height>;
         using Point = std::pair<uint8_t, uint8_t>;
 
-        explicit Screen(std::shared_ptr<SDL2::SDL> sdl, std::uint8_t ratio, const char* title = "Chip8Emu");
+        explicit Screen(const std::shared_ptr<SDL2::SDL>& sdl, std::uint8_t ratio, const char* title = "Chip8Emu");
         void Render(const PixelGrid& grid);
         void DrawPoints(SDL_Color color, const std::vector<SDL_Rect>& rects);
         void DrawSprite(const std::vector<Point>& pixelsOn);

--- a/Chip8Emulator.Core/vendor/timercpp/timercpp.cpp
+++ b/Chip8Emulator.Core/vendor/timercpp/timercpp.cpp
@@ -17,14 +17,14 @@ void Timer::setTimeout(const std::function<void()>& function, int delay)
     t.detach();
 }
 
-void Timer::setInterval(std::function<void()> function, int interval)
+void Timer::setInterval(const std::function<void()>& function, int interval)
 {
-    _setInterval<std::chrono::milliseconds>(std::move(function), interval);
+    _setInterval<std::chrono::milliseconds>(function, interval);
 }
 
-void Timer::setIntervalNs(std::function<void()> function, int interval)
+void Timer::setIntervalNs(const std::function<void()>& function, int interval)
 {
-    _setInterval<std::chrono::nanoseconds>(std::move(function), interval);
+    _setInterval<std::chrono::nanoseconds>(function, interval);
 }
 
 void Timer::stop()

--- a/Chip8Emulator.Core/vendor/timercpp/timercpp.cpp
+++ b/Chip8Emulator.Core/vendor/timercpp/timercpp.cpp
@@ -3,7 +3,9 @@
 // commit: fbf911046b46f4fa68e3a94d004acb3d9de41f10
 #include "timercpp.hpp"
 
-void Timer::setTimeout(std::function<void()> function, int delay)
+#include <utility>
+
+void Timer::setTimeout(const std::function<void()>& function, int delay)
 {
     active = true;
     std::thread t([=]() {
@@ -17,12 +19,12 @@ void Timer::setTimeout(std::function<void()> function, int delay)
 
 void Timer::setInterval(std::function<void()> function, int interval)
 {
-    _setInterval<std::chrono::milliseconds>(function, interval);
+    _setInterval<std::chrono::milliseconds>(std::move(function), interval);
 }
 
 void Timer::setIntervalNs(std::function<void()> function, int interval)
 {
-    _setInterval<std::chrono::nanoseconds>(function, interval);
+    _setInterval<std::chrono::nanoseconds>(std::move(function), interval);
 }
 
 void Timer::stop()

--- a/Chip8Emulator.Core/vendor/timercpp/timercpp.hpp
+++ b/Chip8Emulator.Core/vendor/timercpp/timercpp.hpp
@@ -14,7 +14,7 @@ class Timer {
     std::atomic<bool> active = true;
 
     template <typename Duration>
-    void _setInterval(std::function<void()> function, int interval)
+    void _setInterval(const std::function<void()>& function, int interval)
     {
         active = true;
         std::thread t([=]() {
@@ -29,7 +29,7 @@ class Timer {
 
     public:
         void setTimeout(const std::function<void()>& function, int delay);
-        void setInterval(std::function<void()> function, int interval);
-        void setIntervalNs(std::function<void()> function, int interval);
+        void setInterval(const std::function<void()>& function, int interval);
+        void setIntervalNs(const std::function<void()>& function, int interval);
         void stop();
 };

--- a/Chip8Emulator.Core/vendor/timercpp/timercpp.hpp
+++ b/Chip8Emulator.Core/vendor/timercpp/timercpp.hpp
@@ -28,7 +28,7 @@ class Timer {
     }
 
     public:
-        void setTimeout(std::function<void()> function, int delay);
+        void setTimeout(const std::function<void()>& function, int delay);
         void setInterval(std::function<void()> function, int interval);
         void setIntervalNs(std::function<void()> function, int interval);
         void stop();


### PR DESCRIPTION
like copies, depreciated uses or mix of *smart_ptr and smart_ptr.get() (only the dereferences op is useful in this case, smart_ptr are well coded)